### PR TITLE
generateVRT() added, bug fixes and refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,51 @@
 # Procesamiento de archivos Geotiff
+
 Script en Python para procesar ortomosaicos/geotifs para subirlos a geoservers como capa raster, y a la nube para ser descargados.
 
 El script crea los siguientes archivos optimizados:
+
 - para subir al geoserver
-    - .tif en calidad intermedia (con overviews/render piramidal en diferentes escalas), EPSG:3857
-    - .geojson con el contorno de la imagen para subir al wms, con los campos gsd, srs, registroid y date (si existe)
+  - .tif en calidad intermedia (con overviews/render piramidal en diferentes escalas), EPSG:3857
+  - .geojson con el contorno de la imagen para subir al wms, con los campos gsd, srs, registroid y date (si existe)
 - para subir a la nube:
-    - .tif en calidad baja para usar como preview (w:650px), EPSG original
-    - .tif en calidad media/alta para ser alojado en la nube, EPSG original
-    - .tfw con la información geoespacial
+  - .tif en calidad baja para usar como preview (w:650px), EPSG original
+  - .tif en calidad media/alta para ser alojado en la nube, EPSG original
+  - .tfw con la información geoespacial
 
 ## Instalación
+
 - Descargar e instalar [Python](https://www.python.org/downloads/)
 - Testear en console `python --version` y `pip --version` para corroborar que esté todo andando.
 - Descargar [GDAL](https://www.lfd.uci.edu/~gohlke/pythonlibs/#gdal), seleccionando la versión más nueva de GDAL, y la adecuada según la versión de Python instalado y el procesador. Instalar usando `pip install GDAL-3.3.1-cp37-cp37m-win_amd64.whl` (ajustando según la versión descargada).
 - Descargar [Rasterio](https://www.lfd.uci.edu/~gohlke/pythonlibs/#rasterio), seleccionando versión análoga al GDAL, e instalar del mismo modo.
 - Para poder usar el paquete instalado desde la consola, configurar variables de entorno (poniendo la ruta completa según donde esté instalado el paquete):
-    - `GDAL_DATA`: '...\Python\Python37\Lib\site-packages\osgeo\data\gdal'
-    - `PROJ_LIB`: '...\Python\Python37\Lib\site-packages\osgeo\data\proj'
-    - Agregar a la variable `Path` la ruta '...\Python\Python37\Lib\site-packages\osgeo'
-    - Chequear en consola `gdalinfo --version`.
-- Instalar la librería Numpy mediante el comando  `pip install numpy`.
+  - `GDAL_DATA`: '...\Python\Python37\Lib\site-packages\osgeo\data\gdal'
+  - `PROJ_LIB`: '...\Python\Python37\Lib\site-packages\osgeo\data\proj'
+  - Agregar a la variable `Path` la ruta '...\Python\Python37\Lib\site-packages\osgeo'
+  - Chequear en consola `gdalinfo --version`.
+- Instalar la librería Numpy mediante el comando `pip install numpy`.
 - Instalar la librería PIL mediante el comando `pip install pillow`.
 
 ## Uso
+
 - Colocar los ortomosaicos .tif/.tiff en máxima resolución disponible en la carpeta `input`.
 - Ponerles como nombre el número de registro audiovisual al que pertenecen (este dato será incorporado como metadata en los archivos procesados). NOTA: en caso de que un registro tenga más de un mapeo, agregarle al final de cada nombre de archivo un guión y el número; `-1`,`-2`, etc.
 - Si se desea procesar un archivo geotiff MDE (Modelo Digital de Elevación), ingresar a continuación del número de registro audiovisual el número de MapId al que pertenece y el sufijo `_mde`, quedando una estructura análoga a `12345678_MapId-123445_mde.tif`.
-- En caso de volver a procesar un mismo ortomosaico, debe ingresar como nombre del archivo, el obtenido del procesamiento original. 
+- En caso de volver a procesar un mismo ortomosaico, debe ingresar como nombre del archivo, el obtenido del procesamiento original.
 - Ejecutar `python process.py` para iniciar la conversión. Los archivos procesados serán creados en la carpeta `output`.
 
 ## Configuración
+
 - De ser necesario modificar archivo `params.py` según formatos de exportación, metadata y carpetas.
 
 ## Combinación de múltiples tiles/mapeos en un solo VRT
-- Primero, separar por carpetas el agrupamiento de imágenes deseado
-- Desde consola generarmos una lista con todos los tif contenidos allí ejecutando por cada cada carpeta:
-    - `cmd /r dir /B /S *.tif > list.txt`
-    - NOTA: Si se hace desde PowerShell y el .txt no es utf-8, ejecutar `$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'` y volver a hacer el paso anterior.
-- En el archivo `list.txt` figurará el listado con las rutas absolutas a cada una de las imágenes.
-- Desde consola, ejecutar `gdalbuildvrt -input_file_list list.txt mosaic.vrt` para generar el archivo mosaic.vrt que contendrá referencias a cada una de las imágenes originales.
-- Mover el archivo mosaic.vrt a la carpeta `input` y aplicar nomenclatura/nombrado habitual.
-- Nota: tener en cuenta que el archivo .vrt solo linkea a las imágenes originales, por lo que deben conservarse los archivos originales para que este pueda usarse.
 
+- Separar por carpetas el agrupamiento de imágenes deseado.
+- Colocar las carpetas generadas en la carpeta `input`, respetando el nombre de cada una de ellas de acuerdo el número de registro.
+- En caso de haber una carpeta correspondiente a un ortomosaico MDE, aclararlo durante el nombramiento de dicha carpeta. Por ejemplo, si el número de registro de la versión MDE es '123456', establecer como nombre de carpeta '123456_mde'.
 
 ## TODO
+
 - Subir automáticamente los archivos storage a la red
 - Escribir directamente en base de datos lo que se guarda en la carpeta _database_
 - Dividir archivo process.py en diferentes módulos
-
-

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ El script crea los siguientes archivos optimizados:
 
 - Separar por carpetas el agrupamiento de imágenes deseado.
 - Colocar las carpetas generadas en la carpeta `input`, respetando el nombre de cada una de ellas de acuerdo el número de registro.
-- En caso de haber una carpeta correspondiente a un ortomosaico MDE, aclararlo durante el nombramiento de dicha carpeta. Por ejemplo, si el número de registro de la versión MDE es '123456', establecer como nombre de carpeta '123456_mde'.
+- En caso de haber una carpeta correspondiente a un ortomosaico MDE, aclararlo durante el nombramiento de dicha carpeta. Por ejemplo, si el número de registro de la versión MDE es `123456`, establecer como nombre de carpeta `123456_mde`.
 
 ## TODO
 

--- a/export_formats/gdalinfo.py
+++ b/export_formats/gdalinfo.py
@@ -8,7 +8,7 @@ def exportGdalinfo(self, ds):
     Export a JSON file with the gdalinfo data
     '''
 
-    gdaloutput = f'{params.output_folder_database}/{self.outputFilename}{params.gdalinfo_suffix}.json'
+    gdaloutput = f'{params.output_folder_database_jsondata}/{self.outputFilename}{params.gdalinfo_suffix}.json'
 
     print(f'-> Exporting gdalinfo data {gdaloutput}')
 

--- a/export_formats/geoserverDEM.py
+++ b/export_formats/geoserverDEM.py
@@ -8,6 +8,7 @@ import params as params
 
 TEMP_FOLDER = params.tmp_folder
 
+
 def exportGeoserverDEM(self, file_ds, file):
     ''''
     Exports two geoserver versions:
@@ -27,16 +28,18 @@ def exportGeoserverDEM(self, file_ds, file):
     # change all tiff noData values to the same value
     if (kwargs['srcNodata'] != params.no_data and kwargs['srcNodata'] != 'none'):
         kwargs['dstNodata'] = params.no_data
-        print(f'-> Changing noData value from {self.noDataValue} to {params.no_data}')
+        print(
+            f'-> Changing noData value from {self.noDataValue} to {params.no_data}')
 
     # if file has diferent epsg, convert
     if (self.epsg != params.geoserver_epsg):
-        kwargs['srcSRS'] = 'EPSG:{}'.format(self.epsg)
-        kwargs['dstSRS'] = 'EPSG:{}'.format(params.geoserver_epsg)
-        print(f'-> Transforming EPSG:{self.epsg} to EPSG:{params.geoserver_epsg}')
+        kwargs['srcSRS'] = f'EPSG:{self.epsg}'
+        kwargs['dstSRS'] = f'EPSG:{params.geoserver_epsg}'
+        print(
+            f'-> Transforming EPSG:{self.epsg} to EPSG:{params.geoserver_epsg}')
 
     tmpWarp = TEMP_FOLDER + "\\geoserverWarp.tif"
-    
+
     # Use the warp to convert projections, change the GSD and correct the noData values
     file_ds = gdal.Warp(tmpWarp, file_ds, **kwargs)
 
@@ -44,7 +47,7 @@ def exportGeoserverDEM(self, file_ds, file):
 
     if (params.geoserverDEM['enabled']):
         _exportFloat(self, file_ds, outputFilename)
-    
+
     if (params.geoserverDEMRGB['enabled']):
         _exportRGB(self, tmpWarp, outputFilename)
 
@@ -75,15 +78,14 @@ def _exportFloat(self, file_ds, outputFilename):
 
     if (params.geoserverDEM['overviews']):
         h.addOverviews(file_ds)
-    
+
     file_ds = None
 
-    
-def _exportRGB(self, tmpFile, outputFilename):
 
+def _exportRGB(self, tmpFile, outputFilename):
     '''
     Encode grayscale DEM to RGB using:
-    
+
     - Mapbox codification
     elevation = -10000 + ((red * 256 * 256 + green * 256 + blue) * 0.1)
     https://docs.mapbox.com/data/tilesets/guides/access-elevation-data/
@@ -108,7 +110,7 @@ def _exportRGB(self, tmpFile, outputFilename):
 
     # convert nan values no noData
     dem = np.nan_to_num(dem, nan=params.no_data)
-    
+
     if params.geoserverDEMRGB['encoding'] == 'mapbox':
 
         r += np.floor_divide((100000 + dem * 10), 65536)

--- a/export_formats/geoserverRGB.py
+++ b/export_formats/geoserverRGB.py
@@ -6,6 +6,7 @@ import params as params
 
 TEMP_FOLDER = params.tmp_folder
 
+
 def exportGeoserverRGB(self, file_ds, file):
 
     tmpWarp = None
@@ -30,8 +31,8 @@ def exportGeoserverRGB(self, file_ds, file):
 
     # if file has diferent epsg, convert
     if (self.epsg != params.geoserver_epsg):
-        kwargs['srcSRS'] = 'EPSG:{}'.format(self.epsg)
-        kwargs['dstSRS'] = 'EPSG:{}'.format(params.geoserver_epsg)
+        kwargs['srcSRS'] = f'EPSG:{self.epsg}'
+        kwargs['dstSRS'] = f'EPSG:{params.geoserver_epsg}'
         warp = True
         print(
             f'-> Transforming EPSG:{self.epsg} to EPSG:{params.geoserver_epsg}')

--- a/export_formats/outlines.py
+++ b/export_formats/outlines.py
@@ -4,12 +4,13 @@ import params as params
 
 TEMP_FOLDER = params.tmp_folder
 
+
 def exportOutline(self, file_ds):
     '''
     Export a vector file with the raster's outline. This file
     must be uploaded to the wms layer in the geoserver
     '''
-    
+
     # Final vector file
     gdaloutput = f'{params.output_folder_database_outlines}/{self.outputFilename}.geojson'
     print(f'-> Exporting outline {gdaloutput}')
@@ -113,8 +114,7 @@ def exportOutline(self, file_ds):
             feature.SetField('registro_id', self.registroid)
 
             if self.date:
-                dateFormated = '{}-{}-{}'.format(self.date.strftime(
-                    "%Y"), self.date.strftime("%m"), self.date.strftime("%d"))
+                dateFormated = f'{self.date.strftime("%Y")}-{self.date.strftime("%m")}-{self.date.strftime("%d")}'
                 feature.SetField("date", dateFormated)
 
             layer.CreateFeature(feature)

--- a/export_formats/outlines.py
+++ b/export_formats/outlines.py
@@ -11,7 +11,7 @@ def exportOutline(self, file_ds):
     '''
     
     # Final vector file
-    gdaloutput = f'{params.output_folder_database}/{self.outputFilename}.geojson'
+    gdaloutput = f'{params.output_folder_database_outlines}/{self.outputFilename}.geojson'
     print(f'-> Exporting outline {gdaloutput}')
 
     geoDriver = ogr.GetDriverByName("GeoJSON")

--- a/export_formats/previews.py
+++ b/export_formats/previews.py
@@ -5,8 +5,6 @@ from osgeo_utils.gdal_calc import Calc
 
 import params as params
 
-TEMP_FOLDER = params.tmp_folder
-
 
 def exportStoragePreview(self, geotiff):
 
@@ -48,13 +46,12 @@ def getColoredHillshade(self, geotiff):
     '''
     Create a colored hillshade result from merging hillshade / DEM
     '''
-    tmpColorRelief = '{}\\colorRelief.tif'.format(TEMP_FOLDER)
-    tmpHillshade = '{}\\hillshade.tif'.format(TEMP_FOLDER)
-    tmpGammaHillshade = '{}\\gammaHillshade.tif'.format(TEMP_FOLDER)
-    tmpColoredHillshade = '{}\\coloredHillshade.tif'.format(TEMP_FOLDER)
-    tmpColoredHillshadeContrast = '{}\\coloredHillshadeC.tif'.format(
-        TEMP_FOLDER)
-    tmpFileColorPath = '{}\\colorPalette.txt'.format(TEMP_FOLDER)
+    tmpColorRelief = f'{params.tmp_folder}\\colorRelief.tif'
+    tmpHillshade = f'{params.tmp_folder}\\hillshade.tif'
+    tmpGammaHillshade = f'{params.tmp_folder}\\gammaHillshade.tif'
+    tmpColoredHillshade = f'{params.tmp_folder}\\coloredHillshade.tif'
+    tmpColoredHillshadeContrast = f'{params.tmp_folder}\\coloredHillshadeC.tif'
+    tmpFileColorPath = f'{params.tmp_folder}\\colorPalette.txt'
 
     fileColor = open(tmpFileColorPath, 'w')
 

--- a/export_formats/quantities.py
+++ b/export_formats/quantities.py
@@ -1,14 +1,14 @@
 import params as params
 
+
 def exportQuantities(self):
-    
-    quantitiesPath = '{}\\{}.txt'.format(
-        params.output_folder_database_mdevalues, self.outputFilename)
+
+    quantitiesPath = f'{params.output_folder_database_mdevalues}\\{self.outputFilename}.txt'
 
     print(f'-> Exporting quantities {quantitiesPath}')
 
     colorValues = self.colorValues
-    
+
     quantities = []
 
     i = 0
@@ -16,7 +16,7 @@ def exportQuantities(self):
         # Generating a color palette merging two structures
         quantities.append(str(round(colorValues[i], 6)))
         i += 1
-    
+
     string = f'{{{",".join(quantities)}}}'
 
     fileQuantities = open(quantitiesPath, 'w')

--- a/export_formats/quantities.py
+++ b/export_formats/quantities.py
@@ -3,7 +3,7 @@ import params as params
 def exportQuantities(self):
     
     quantitiesPath = '{}\\{}.txt'.format(
-        params.output_folder_database, self.outputFilename)
+        params.output_folder_database_mdevalues, self.outputFilename)
 
     print(f'-> Exporting quantities {quantitiesPath}')
 

--- a/export_formats/storageDEM.py
+++ b/export_formats/storageDEM.py
@@ -6,18 +6,19 @@ from export_formats.gdalinfo import exportGdalinfo
 
 TEMP_FOLDER = params.tmp_folder
 
+
 def exportStorageDEM(self, file_ds):
 
-    outputFilename = '{}.tif'.format(self.outputFilename)
+    outputFilename = f'{self.outputFilename}.tif'
 
     gdaloutput = self.outputFolder
 
-    gdaloutput = '{}/{}'.format(gdaloutput, outputFilename)
+    gdaloutput = f'{gdaloutput}/{outputFilename}'
 
     print(f'-> Exporting {gdaloutput}')
 
     tmpWarp = None
-    
+
     warp = False
 
     kwargs = {
@@ -58,10 +59,10 @@ def exportStorageDEM(self, file_ds):
     }
 
     geotiff = gdal.Translate(gdaloutput, file_ds, **kwargs)
-    
+
     if params.storageDEM['overviews']:
         addOverviews(geotiff)
-    
+
     if params.storageDEM['gdalinfo']:
         exportGdalinfo(self, geotiff)
 

--- a/export_formats/storageDEM.py
+++ b/export_formats/storageDEM.py
@@ -22,8 +22,8 @@ def exportStorageDEM(self, file_ds):
 
     kwargs = {
         'format': 'GTiff',
-        'xRes': params.storageDEM['gsd']/100,
-        'yRes': params.storageDEM['gsd']/100,
+        'xRes': params.storageDEM['gsd']/100 if params.storageDEM['gsd'] else self.pixelSizeX,
+        'yRes': params.storageDEM['gsd']/100 if params.storageDEM['gsd'] else self.pixelSizeY,
         'multithread': True,
         # force 'none' to fix old error in Drone Deploy exports (https://gdal.org/programs/gdal_translate.html#cmdoption-gdal_translate-a_nodata)
         'srcNodata': 'none' if self.hasAlphaChannel else self.noDataValue
@@ -42,8 +42,8 @@ def exportStorageDEM(self, file_ds):
 
     kwargs = {
         'format': 'GTiff',
-        'xRes': params.storageDEM['gsd']/100,
-        'yRes': params.storageDEM['gsd']/100,
+        'xRes': params.storageDEM['gsd']/100 if params.storageDEM['gsd'] else self.pixelSizeX,
+        'yRes': params.storageDEM['gsd']/100 if params.storageDEM['gsd'] else self.pixelSizeY,
         'bandList': [1],
         'creationOptions': [
             'BIGTIFF=YES',  # for files larger than 4 GB

--- a/export_formats/storageRGB.py
+++ b/export_formats/storageRGB.py
@@ -6,13 +6,14 @@ from export_formats.gdalinfo import exportGdalinfo
 
 TEMP_FOLDER = params.tmp_folder
 
+
 def exportStorageRGB(self, file_ds):
 
-    outputFilename = '{}.tif'.format(self.outputFilename)
+    outputFilename = f'{self.outputFilename}.tif'
 
     gdaloutput = self.outputFolder
 
-    gdaloutput = '{}/{}'.format(gdaloutput, outputFilename)
+    gdaloutput = f'{gdaloutput}/{outputFilename}'
 
     print(f'-> Exporting {gdaloutput}')
 

--- a/generateVRT.py
+++ b/generateVRT.py
@@ -1,0 +1,33 @@
+import os
+import tempfile
+from osgeo import gdal
+
+tmp_folder = f'{tempfile.gettempdir()}/geotiff-processor'
+
+
+def generateVRT():
+
+    salida = []
+    ruta = r'E:\geotiff-processor\input'
+    cont = os.listdir(ruta)
+    for i in cont:
+        finalpath = ruta + os.sep + i
+        for path, dirs, files in os.walk(finalpath):
+
+            filepath = tmp_folder + '\\list.txt'
+
+            with open(filepath, "w") as l:
+                for file in files:
+                    ok = path + os.sep + file
+                    l.write(ok + '\n')
+
+            with open(filepath, 'r') as f:
+                for linea in f:
+                    salida += linea.split()
+
+            output = ruta + os.sep + i + '.vrt'
+
+            ds = gdal.BuildVRT(output, salida)
+            ds = None  # ds.FlushCache()
+
+            salida.clear()

--- a/generateVRT.py
+++ b/generateVRT.py
@@ -1,33 +1,30 @@
 import os
-import tempfile
 from osgeo import gdal
+import params as params
 
-tmp_folder = f'{tempfile.gettempdir()}/geotiff-processor'
+tmp_folder = params.tmp_folder
 
 
-def generateVRT():
-
-    salida = []
-    ruta = r'E:\geotiff-processor\input'
-    cont = os.listdir(ruta)
-    for i in cont:
-        finalpath = ruta + os.sep + i
-        for path, dirs, files in os.walk(finalpath):
-
-            filepath = tmp_folder + '\\list.txt'
-
-            with open(filepath, "w") as l:
-                for file in files:
+pathList = []
+root_path = params.input_folder
+cont = os.listdir(root_path)
+for i in cont:
+    finalpath = root_path + os.sep + i
+    for path, dirs, files in os.walk(finalpath):
+        filepath = params.tmp_folder + '\\list.txt'
+        with open(filepath, "w") as l:
+            for file in files:
+                if(file.endswith(".tif")):
                     ok = path + os.sep + file
                     l.write(ok + '\n')
 
-            with open(filepath, 'r') as f:
-                for linea in f:
-                    salida += linea.split()
+        with open(filepath, 'r') as f:
+            for line in f:
+                pathList.append(line.split('\n')[0])
 
-            output = ruta + os.sep + i + '.vrt'
+        output = root_path + os.sep + i + '.vrt'
 
-            ds = gdal.BuildVRT(output, salida)
-            ds = None  # ds.FlushCache()
+        ds = gdal.BuildVRT(output, pathList)
+        ds = None  # ds.FlushCache()
 
-            salida.clear()
+        pathList.clear()

--- a/generateVRT.py
+++ b/generateVRT.py
@@ -23,7 +23,6 @@ def generateVRT():
                     pathList.append(line.split('\n')[0])
 
             output = root_path + os.sep + i + '.vrt'
-            ds = gdal.BuildVRT(output, pathList)
-            ds = None  # ds.FlushCache()
+            gdal.BuildVRT(output, pathList)
 
             pathList.clear()

--- a/generateVRT.py
+++ b/generateVRT.py
@@ -2,29 +2,28 @@ import os
 from osgeo import gdal
 import params as params
 
-tmp_folder = params.tmp_folder
 
+def generateVRT():
 
-pathList = []
-root_path = params.input_folder
-cont = os.listdir(root_path)
-for i in cont:
-    finalpath = root_path + os.sep + i
-    for path, dirs, files in os.walk(finalpath):
-        filepath = params.tmp_folder + '\\list.txt'
-        with open(filepath, "w") as l:
-            for file in files:
-                if(file.endswith(".tif")):
-                    ok = path + os.sep + file
-                    l.write(ok + '\n')
+    pathList = []
+    root_path = params.input_folder
+    cont = os.listdir(root_path)
+    for i in cont:
+        finalpath = root_path + os.sep + i
+        for path, dirs, files in os.walk(finalpath):
+            filepath = params.tmp_folder + 'list.txt'
+            with open(filepath, "w") as l:
+                for file in files:
+                    if(file.endswith(".tif")):
+                        ok = path + os.sep + file
+                        l.write(ok + '\n')
 
-        with open(filepath, 'r') as f:
-            for line in f:
-                pathList.append(line.split('\n')[0])
+            with open(filepath, 'r') as f:
+                for line in f:
+                    pathList.append(line.split('\n')[0])
 
-        output = root_path + os.sep + i + '.vrt'
+            output = root_path + os.sep + i + '.vrt'
+            ds = gdal.BuildVRT(output, pathList)
+            ds = None  # ds.FlushCache()
 
-        ds = gdal.BuildVRT(output, pathList)
-        ds = None  # ds.FlushCache()
-
-        pathList.clear()
+            pathList.clear()

--- a/generateVRT.py
+++ b/generateVRT.py
@@ -11,7 +11,7 @@ def generateVRT():
     for i in cont:
         finalpath = root_path + os.sep + i
         for path, dirs, files in os.walk(finalpath):
-            filepath = params.tmp_folder + 'list.txt'
+            filepath = params.tmp_folder + '\list.txt'
             with open(filepath, "w") as l:
                 for file in files:
                     if(file.endswith(".tif")):

--- a/helpers.py
+++ b/helpers.py
@@ -22,6 +22,9 @@ def createFolder(folderPath):
 def removeExtension(filename):
     return os.path.splitext(filename)[0]
 
+def getExtension(filename):
+    return os.path.splitext(filename)[1]
+
 
 def getDateFromMetadata(file_ds):
     '''

--- a/helpers.py
+++ b/helpers.py
@@ -142,7 +142,7 @@ def getLightVersion(file_ds):
     print('-> Generating lightweight version')
 
     # tmp file
-    tmpGeotiffCompressed = '{}\\compressedLowRes.tif'.format(TEMP_FOLDER)
+    tmpGeotiffCompressed = f'{params.tmp_folder}\\compressedLowRes.tif'
 
     geotiff = gdal.Warp(
         tmpGeotiffCompressed,
@@ -157,21 +157,20 @@ def getLightVersion(file_ds):
     return geotiff
 
 
-def checkFileProcessed(self, filenameHasMapId, isMDE, processed, file):
+def checkFileProcessed(self, isMDE, processed, file):
     '''
     Check if the file has already been processed before to reuse hash,
     instead of generating a new one (process rgb and dem at the same time).
     '''
 
-    if not filenameHasMapId:
-        exist = False
-        f = file.split(params.dem_suffix)[
-            0] if isMDE else removeExtension(file)
-        for i in processed:  # dictionary elements
-            if(f in i):  
-                exist = True
-                self.mapId = processed.get(f)  # take existing hash
-                break
-        if not exist:
-            # if it was never processed, I add it to the dict
-            processed[f] = self.mapId
+    hasProcessed = False
+    regid = file.split(params.dem_suffix)[
+        0] if isMDE else removeExtension(file)
+    for i in processed:  # dictionary elements
+        if(regid in i):
+            hasProcessed = True  
+            self.mapId = processed.get(regid)  # take existing hash
+            break
+    if not hasProcessed:
+        # if it was never processed, I add it to the dict
+        processed[regid] = self.mapId

--- a/helpers.py
+++ b/helpers.py
@@ -155,3 +155,23 @@ def getLightVersion(file_ds):
     )
 
     return geotiff
+
+
+def checkFileProcessed(self, filenameHasMapId, isMDE, processed, file):
+    '''
+    Check if the file has already been processed before to reuse hash,
+    instead of generating a new one (process rgb and dem at the same time).
+    '''
+
+    if not filenameHasMapId:
+        exist = False
+        f = file.split(params.dem_suffix)[
+            0] if isMDE else removeExtension(file)
+        for i in processed:  # dictionary elements
+            if(f in i):  
+                exist = True
+                self.mapId = processed.get(f)  # take existing hash
+                break
+        if not exist:
+            # if it was never processed, I add it to the dict
+            processed[f] = self.mapId

--- a/params.py
+++ b/params.py
@@ -1,6 +1,7 @@
 import tempfile
 
 tmp_folder = f'{tempfile.gettempdir()}/geotiff-processor'
+extensions = ['.tif', '.tiff', '.vrt']
 
 input_folder = 'input'
 output_folder = 'output'
@@ -77,7 +78,7 @@ storageRGB = {
 
 storageDEM = {
     'enabled': True,
-    'gsd': None,  # cm
+    'gsd': 20,  # cm
     'overviews': True,
     'quantities': True,
     'gdalinfo': True

--- a/params.py
+++ b/params.py
@@ -7,6 +7,9 @@ output_folder = 'output'
 
 output_folder_storage = f'{output_folder}/storage'
 output_folder_database = f'{output_folder}/database'
+output_folder_database_jsondata = f'{output_folder_database}/jsondata'
+output_folder_database_mdevalues = f'{output_folder_database}/mdevalues'
+output_folder_database_outlines = f'{output_folder_database}/outlines'
 output_folder_geoserver = f'{output_folder}/geoserver'
 
 filename_prefix = '_MapId-'

--- a/params.py
+++ b/params.py
@@ -74,7 +74,7 @@ storageRGB = {
 
 storageDEM = {
     'enabled': True,
-    'gsd': 20,  # cm
+    'gsd': None,  # cm
     'overviews': True,
     'quantities': True,
     'gdalinfo': True

--- a/process.py
+++ b/process.py
@@ -6,6 +6,7 @@ import math
 
 import params as params
 import helpers as h
+import generateVRT as vrt
 
 from export_formats.storageRGB import exportStorageRGB
 from export_formats.storageDEM import exportStorageDEM
@@ -89,8 +90,8 @@ class ConvertGeotiff:
         for subdir, dirs, files in os.walk(params.input_folder):
             for file in files:
                 filepath = subdir + os.sep + file
-
-                if (file.endswith(".tif") | file.endswith(".tiff") | file.endswith(".vrt")):
+                is_subdir = subdir != params.input_folder
+                if ((file.endswith(".tif") | file.endswith(".tiff") | file.endswith(".vrt")) and (not is_subdir)):
                     try:
 
                         print(f'--> PROCESSING FILE {file} <--')
@@ -228,5 +229,6 @@ class ConvertGeotiff:
             print('-> Removing temp folder')
             shutil.rmtree(params.tmp_folder)
 
-
+if(os.listdir(params.input_folder)):
+    vrt.generateVRT()
 ConvertGeotiff()

--- a/process.py
+++ b/process.py
@@ -68,6 +68,12 @@ class ConvertGeotiff:
 
         h.createFolder(params.output_folder_database)
 
+        h.createFolder(params.output_folder_database_jsondata)
+
+        h.createFolder(params.output_folder_database_mdevalues)
+    
+        h.createFolder(params.output_folder_database_outlines)
+
         h.createFolder(params.output_folder_storage)
 
         # geoserver folders

--- a/process.py
+++ b/process.py
@@ -97,7 +97,7 @@ class ConvertGeotiff:
 
             for file in files:
                 filepath = subdir + os.sep + file
-                if (file.endswith(".tif") | file.endswith(".tiff") | file.endswith(".vrt")):
+                if (h.getExtension(file) in params.extensions):
                     try:
 
                         print(f'--> PROCESSING FILE {file} <--')

--- a/process.py
+++ b/process.py
@@ -1,4 +1,3 @@
-from operator import is_
 import sys
 import os
 import shutil
@@ -93,101 +92,105 @@ class ConvertGeotiff:
         # Find files in the input folder
         for subdir, dirs, files in os.walk(params.input_folder):
             is_subdir = subdir != params.input_folder
-            if(not is_subdir):
-                for file in files:
-                    filepath = subdir + os.sep + file
-                    if (file.endswith(".tif") | file.endswith(".tiff") | file.endswith(".vrt")):
-                        try:
+            if(is_subdir):
+                continue
 
-                            print(f'--> PROCESSING FILE {file} <--')
+            for file in files:
+                filepath = subdir + os.sep + file
+                if (file.endswith(".tif") | file.endswith(".tiff") | file.endswith(".vrt")):
+                    try:
 
-                            file_ds = gdal.Open(filepath, gdal.GA_ReadOnly)
-                            # Number of bands
-                            bands = file_ds.RasterCount
-                            self.isDEM = bands <= 2
+                        print(f'--> PROCESSING FILE {file} <--')
 
-                            lastBand = file_ds.GetRasterBand(bands)
-                            self.hasAlphaChannel = (
-                                lastBand.GetColorInterpretation() == 6)  # https://github.com/rasterio/rasterio/issues/100
-                            self.noDataValue = lastBand.GetNoDataValue()  # take any band
+                        file_ds = gdal.Open(filepath, gdal.GA_ReadOnly)
+                        # Number of bands
+                        bands = file_ds.RasterCount
+                        self.isDEM = bands <= 2
 
-                            # Pix4DMatic injects an erroneous 'nan' value as noData attribute
-                            if ((self.noDataValue != None) and (math.isnan(self.noDataValue))):
-                                self.noDataValue = 0
+                        lastBand = file_ds.GetRasterBand(bands)
+                        self.hasAlphaChannel = (
+                            lastBand.GetColorInterpretation() == 6)  # https://github.com/rasterio/rasterio/issues/100
+                        self.noDataValue = lastBand.GetNoDataValue()  # take any band
 
-                            filenameHasMapId = params.filename_prefix in file
+                        # Pix4DMatic injects an erroneous 'nan' value as noData attribute
+                        if ((self.noDataValue != None) and (math.isnan(self.noDataValue))):
+                            self.noDataValue = 0
 
-                            if (self.isDEM):
+                        filenameHasMapId = params.filename_prefix in file
 
-                                print(f'-> File {file} is DEM type')
+                        if (self.isDEM):
 
-                                # Generating output filename for DME case
-                                self.mapId = h.removeExtension(file.split(
-                                    params.filename_prefix)[1].split(params.dem_suffix)[0]) if filenameHasMapId else h.createMapId()
+                            print(f'-> File {file} is DEM type')
 
+                            # Generating output filename for DME case
+                            self.mapId = h.removeExtension(file.split(
+                                params.filename_prefix)[1].split(params.dem_suffix)[0]) if filenameHasMapId else h.createMapId()
+
+                            if(not filenameHasMapId):
                                 h.checkFileProcessed(
-                                    self, filenameHasMapId, True, processed, file)
+                                    self, True, processed, file)
 
-                                self.registroid = file.split(
-                                    params.filename_prefix)[0] if filenameHasMapId else h.cleanFilename(h.removeExtension(file.split(params.dem_suffix)[0]))
-                            else:
+                            self.registroid = file.split(
+                                params.filename_prefix)[0] if filenameHasMapId else h.cleanFilename(h.removeExtension(file.split(params.dem_suffix)[0]))
+                        else:
 
-                                print(f'-> File {file} is RGB type')
+                            print(f'-> File {file} is RGB type')
 
-                                self.mapId = h.removeExtension(
-                                    file.split(params.filename_prefix)[1]) if filenameHasMapId else h.createMapId()
+                            self.mapId = h.removeExtension(
+                                file.split(params.filename_prefix)[1]) if filenameHasMapId else h.createMapId()
 
+                            if(not filenameHasMapId):
                                 h.checkFileProcessed(
-                                    self, filenameHasMapId, False, processed, file)
+                                    self, False, processed, file)
 
-                                self.registroid = file.split(
-                                    "_")[0] if filenameHasMapId else h.cleanFilename(h.removeExtension(file))
+                            self.registroid = file.split(
+                                "_")[0] if filenameHasMapId else h.cleanFilename(h.removeExtension(file))
 
-                            output = f'{self.registroid}{params.filename_prefix}{self.mapId}'
+                        output = f'{self.registroid}{params.filename_prefix}{self.mapId}'
 
-                            # Create parent folder for mapId
-                            self.outputFolder = f'{params.output_folder_storage}/{output}'
-                            h.createFolder(self.outputFolder)
+                        # Create parent folder for mapId
+                        self.outputFolder = f'{params.output_folder_storage}/{output}'
+                        h.createFolder(self.outputFolder)
 
-                            self.outputFilename = output if not self.isDEM else '{}{}'.format(
-                                output, params.dem_suffix)
+                        self.outputFilename = output if not self.isDEM else '{}{}'.format(
+                            output, params.dem_suffix)
 
-                            print(
-                                f'-> Files for {self.outputFilename} will be exported')
+                        print(
+                            f'-> Files for {self.outputFilename} will be exported')
 
-                         # File GSD
-                            gt = file_ds.GetGeoTransform()
-                            self.pixelSizeX = gt[1]
-                            self.pixelSizeY = -gt[5]
+                        # File GSD
+                        gt = file_ds.GetGeoTransform()
+                        self.pixelSizeX = gt[1]
+                        self.pixelSizeY = -gt[5]
 
-                            # file's GSD: get average x and y values
-                            self.originalGsd = round(
-                                (self.pixelSizeY + self.pixelSizeX) / 2 * 100, 2)  # cm
+                        # file's GSD: get average x and y values
+                        self.originalGsd = round(
+                            (self.pixelSizeY + self.pixelSizeX) / 2 * 100, 2)  # cm
 
-                            # File Projection
-                            self.epsg = h.getEPSGCode(file_ds)
+                        # File Projection
+                        self.epsg = h.getEPSGCode(file_ds)
 
-                            self.date = h.getDateFromMetadata(file_ds)
+                        self.date = h.getDateFromMetadata(file_ds)
 
-                            self.extra_metadata = params.metadata
+                        self.extra_metadata = params.metadata
 
-                            self.extra_metadata.append(
-                                'registroId={}'.format(self.registroid))
+                        self.extra_metadata.append(
+                            'registroId={}'.format(self.registroid))
 
-                            self.extra_metadata.append(
-                                'mapId={}'.format(self.mapId))
+                        self.extra_metadata.append(
+                            'mapId={}'.format(self.mapId))
 
-                            self.exportStorageFiles(file_ds)
+                        self.exportStorageFiles(file_ds)
 
-                            self.exportGeoserverFiles(file_ds, file)
+                        self.exportGeoserverFiles(file_ds, file)
 
-                            # Once we're done, close properly the dataset
-                            file_ds = None
+                        # Once we're done, close properly the dataset
+                        file_ds = None
 
-                        except RuntimeError as e:
-                            print(f'ERROR: Unable to process {filepath}')
-                            print(e)
-                            sys.exit(1)
+                    except RuntimeError as e:
+                        print(f'ERROR: Unable to process {filepath}')
+                        print(e)
+                        sys.exit(1)
 
     def exportStorageFiles(self, file_ds):
         '''


### PR DESCRIPTION
-generateVRT() function allows folder with tiles to be added to the input folder, generating a vrt file which will be processed later.
- if two versions of the same file (rgb, dem) are processed, the hash is maintained, instead of generating two different ones.